### PR TITLE
Use TEST_PHP_ARGS (from run-tests.php) instead of trying to build it

### DIFF
--- a/tests/server_test.inc
+++ b/tests/server_test.inc
@@ -32,7 +32,7 @@ function server_start_one($host, $port, $code = 'echo "Hello world";', $php_opts
 	} else {
 		$php_args = "-d extension_dir=$doc_root/../modules";
 	}
-	$php_args = "$php_args -d extension=$ext";
+	$php_args = (getenv('TEST_PHP_ARGS') ?: "$php_args -d extension=$ext");
 
 	if ($php_opts) {
 		$php_args = "$php_args -d " . implode(' -d ', $php_opts);;


### PR DESCRIPTION
Especially required to run test suite with igbinary as a shared extension

Common way:
```
$ export TEST_PHP_EXECUTABLE=$(which php)
$ export TEST_PHP_ARGS="-n -d extension=igbinary.so -d extension=$PWD/modules/immutable_cache.so"
$ php run-tests.php
```