### PR TITLE
mark igbinary as required

### DIFF
--- a/php_immutable_cache.c
+++ b/php_immutable_cache.c
@@ -625,10 +625,19 @@ PHP_FUNCTION(immutable_cache_exists) {
 }
 /* }}} */
 
+static const zend_module_dep immutable_cache_deps[] = {
+#ifdef IMMUTABLE_CACHE_IGBINARY
+	ZEND_MOD_REQUIRED("igbinary")
+#endif
+	ZEND_MOD_END
+};
+
 /* {{{ module definition structure */
 
 zend_module_entry immutable_cache_module_entry = {
-	STANDARD_MODULE_HEADER,
+	STANDARD_MODULE_HEADER_EX,
+	NULL,
+	immutable_cache_deps,
 	PHP_IMMUTABLE_CACHE_EXTNAME,
 	ext_functions,
 	PHP_MINIT(immutable_cache),


### PR DESCRIPTION
When igbinary not loaded
```

$ php -n -d extension=modules/immutable_cache.so --re immutable_cache

Warning: PHP Startup: Unable to load dynamic library 'modules/immutable_cache.so' (tried: modules/immutable_cache.so (modules/immutable_cache.so: undefined symbol: igbinary_serialize), /usr/lib64/php/modules/modules/immutable_cache.so.so (/usr/lib64/php/modules/modules/immutable_cache.so.so: cannot open shared object file: No such file or directory)) in Unknown on line 0
Exception: Extension "immutable_cache" does not exist

```

So symbols from igbinary are used.

So with this change:

```
$ php -n -d extension=igbinary -d extension=modules/immutable_cache.so --re immutable_cache 
Extension [ <persistent> extension #17 immutable_cache version 6.0.2 ] {

  - Dependencies {
    Dependency [ igbinary (Required) ]
  }

...
```