### PR TITLE
mark igbinary as required when igbinary is compiled with `--enable-immutable-cache-igbinary`

### DIFF
--- a/ci/test_inner.sh
+++ b/ci/test_inner.sh
@@ -7,26 +7,32 @@ echo "Run tests in docker"
 php --version
 php --ini
 
-cp ci/run-tests-parallel.php run-tests.php
-export REPORT_EXIT_STATUS=1
-echo "Test with default representation, creating arrays in shared memory when possible"
-make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=default tests"
-echo "Test with storing serialize() in shared memory when possible"
-make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=php tests"
-echo "Test with opcache enabled and immutable arrays in memory when possible"
-make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=default -d opcache.enable_cli=1 tests"
-echo "Test with opcache enabled and serialize()"
-make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=php -d opcache.enable_cli=1 tests"
-echo "Test with protect_memory on the immutable strings/objects in shared memory"
-make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=default -d immutable_cache.protect_memory=1 tests"
-
 PECL_EXTENSION_DIR=$(php -r "echo ini_get('extension_dir');")
 echo "Pecl extensions are installed in $PECL_EXTENSION_DIR"
+EXTRA_TEST_PHP_ARGS=''
 igbinary_path="$PECL_EXTENSION_DIR/igbinary.so"
 if [[ -f "$igbinary_path" ]]; then
 	cp "$igbinary_path" modules/
 	php -d extension=modules/immutable_cache.so -d extension=modules/igbinary.so -d immutable_cache.serializer=igbinary -r 'phpinfo();'
-	make test TESTS="-j$(nproc) --show-diff -d extension=$PWD/modules/igbinary.so -d immutable_cache.serializer=igbinary tests"
+	EXTRA_TEST_PHP_ARGS="-d extension=$PWD/modules/igbinary.so"
+fi
+
+cp ci/run-tests-parallel.php run-tests.php
+export REPORT_EXIT_STATUS=1
+echo "Test with default representation, creating arrays in shared memory when possible"
+make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=default tests $EXTRA_TEST_PHP_ARGS"
+echo "Test with storing serialize() in shared memory when possible"
+make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=php tests $EXTRA_TEST_PHP_ARGS"
+echo "Test with opcache enabled and immutable arrays in memory when possible"
+make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=default -d opcache.enable_cli=1 tests $EXTRA_TEST_PHP_ARGS"
+echo "Test with opcache enabled and serialize()"
+make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=php -d opcache.enable_cli=1 tests $EXTRA_TEST_PHP_ARGS"
+echo "Test with protect_memory on the immutable strings/objects in shared memory"
+make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=default -d immutable_cache.protect_memory=1 tests $EXTRA_TEST_PHP_ARGS"
+
+if [[ -f "$igbinary_path" ]]; then
+	echo "Test with igbinary serializer"
+	make test TESTS="-j$(nproc) --show-diff -d immutable_cache.serializer=igbinary tests $EXTRA_TEST_PHP_ARGS"
 fi
 
 echo "Test that package.xml is valid"

--- a/php_immutable_cache.c
+++ b/php_immutable_cache.c
@@ -625,10 +625,19 @@ PHP_FUNCTION(immutable_cache_exists) {
 }
 /* }}} */
 
+static const zend_module_dep immutable_cache_deps[] = {
+#ifdef IMMUTABLE_CACHE_IGBINARY
+	ZEND_MOD_REQUIRED("igbinary")
+#endif
+	ZEND_MOD_END
+};
+
 /* {{{ module definition structure */
 
 zend_module_entry immutable_cache_module_entry = {
-	STANDARD_MODULE_HEADER,
+	STANDARD_MODULE_HEADER_EX,
+	NULL,
+	immutable_cache_deps,
 	PHP_IMMUTABLE_CACHE_EXTNAME,
 	ext_functions,
 	PHP_MINIT(immutable_cache),

--- a/tests/server_test.inc
+++ b/tests/server_test.inc
@@ -23,7 +23,8 @@ function server_start_one($host, $port, $code = 'echo "Hello world";', $php_opts
 		2 => STDERR,
 	);
 
-	$ext = (substr(PHP_OS, 0, 3) == 'WIN') ? 'php_immutable_cache.dll' : 'immutable_cache.so';
+	$is_windows = substr(PHP_OS, 0, 3) == 'WIN';
+	$ext = $is_windows ? 'php_immutable_cache.dll' : 'immutable_cache.so';
 	if (substr(PHP_OS, 0, 3) == 'WIN') {
 		$part0 = 8 == PHP_INT_SIZE ? "x64" : "";
 		$part1 = ZEND_DEBUG_BUILD ? "Debug" : "Release";
@@ -32,7 +33,11 @@ function server_start_one($host, $port, $code = 'echo "Hello world";', $php_opts
 	} else {
 		$php_args = "-d extension_dir=$doc_root/../modules";
 	}
-	$php_args = (getenv('TEST_PHP_ARGS') ?: "$php_args -d extension=$ext");
+	$php_args = "$php_args -d extension=$ext";
+	if (extension_loaded('igbinary')) {
+		$igbinary_ext = $is_windows ? 'php_igbinary.dll' : 'igbinary.so';
+		$php_args = "$php_args -d extension=$igbinary_ext";
+	}
 
 	if ($php_opts) {
 		$php_args = "$php_args -d " . implode(' -d ', $php_opts);;


### PR DESCRIPTION
Alternative to #17 , as pointed out by remi collet

This will still fail unless the user manually copies igbinary into the modules folder to run tests, but is still an improvement overall to testability and reporting invalid setups

Patching igbinary to support registration without extension dependency (like how it supports apcu) would be better for convenience

