### PR TITLE
relax test for 8.3

### DIFF
--- a/tests/typed_prop.phpt
+++ b/tests/typed_prop.phpt
@@ -28,8 +28,8 @@ try {
 var_dump($test->array);
 
 ?>
---EXPECT--
+--EXPECTF--
 bool(true)
-Cannot assign bool to reference held by property Test::$array of type array
+Cannot assign %s to reference held by property Test::$array of type array
 array(0) {
 }


### PR DESCRIPTION
Without this:

```
========DIFF========
     bool(true)
002- Cannot assign bool to reference held by property Test::$array of type array
002+ Cannot assign true to reference held by property Test::$array of type array
     array(0) {
     }
========DONE========
FAIL Success parameters should respect property types [tests/typed_prop.phpt] 

```